### PR TITLE
🩹 Fix incorrect variable reference

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -7,7 +7,7 @@ export default {
 
   // Global page headers: https://go.nuxtjs.dev/config-head
   head: {
-    title: process.env.NUXT_ENV_SITE_TITLE || process.env.NUXT_ENV_FULL_NAME,
+    title: process.env.NUXT_ENV_SITE_NAME || process.env.NUXT_ENV_FULL_NAME,
     htmlAttrs: {
       lang: 'en'
     },


### PR DESCRIPTION
Fixed incorrect reference to `NUXT_ENV_SITE_NAME` in config.